### PR TITLE
Update auto-reading workflow and documentation

### DIFF
--- a/.github/workflows/auto-reading.yml
+++ b/.github/workflows/auto-reading.yml
@@ -6,6 +6,14 @@ on:
   #   - cron: '0 0 * * *'    # UTC 00:00 = 北京时间 08:00
   #   - cron: '0 12 * * *'   # UTC 12:00 = 北京时间 20:00
   
+  # 拉取请求触发，用于测试阅读
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'weread-bot.py'
+      - 'requirements.txt'
+      - '.github/workflows/ci.yml'
+
   # 手动触发
   workflow_dispatch:
     inputs:
@@ -57,8 +65,8 @@ jobs:
 
         reading:
           mode: "${{ github.event.inputs.reading_mode || 'smart_random' }}"
-          # 目标阅读时长（分钟），支持区间随机，当前为：2-5分钟
-          target_duration: "${{ github.event.inputs.target_duration || '2-5' }}"
+          # 目标阅读时长（分钟），支持区间随机，格式如："1" 或 "1-2"，当前为：1分钟
+          target_duration: "${{ github.event.inputs.target_duration || '1' }}"
           reading_interval: "30-48"
           use_curl_data_first: true
           fallback_to_config: true

--- a/.github/workflows/auto-reading.yml
+++ b/.github/workflows/auto-reading.yml
@@ -12,7 +12,7 @@ on:
       target_duration:
         description: '阅读时长（分钟，格式：10-20。建议：频繁运行时设置5-10分钟，GitHub免费版每月2000分钟额度）'
         required: false
-        default: '5-10'
+        default: '1-2'
         type: string
       reading_mode:
         description: '阅读模式'
@@ -57,8 +57,8 @@ jobs:
 
         reading:
           mode: "${{ github.event.inputs.reading_mode || 'smart_random' }}"
-          # 目标阅读时长（分钟），支持区间随机，当前为：45-90分钟
-          target_duration: "${{ github.event.inputs.target_duration || '45-90' }}"
+          # 目标阅读时长（分钟），支持区间随机，当前为：2-5分钟
+          target_duration: "${{ github.event.inputs.target_duration || '2-5' }}"
           reading_interval: "30-48"
           use_curl_data_first: true
           fallback_to_config: true

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ open config-generator.html
 - 配置：设置 `APPRISE_URL`，格式如：
   - Discord: `discord://webhook_id/webhook_token`
   - Email: `mailto://user:pass@domain.com`
+  - 自部署 Apprise 服务器: `apprises://your_apprise_server.com/your_apprise_token/?tags=pro`
   - 更多格式见：[Apprise文档](https://github.com/caronc/apprise)
 
 #### Bark（iOS推送）
@@ -330,6 +331,8 @@ open config-generator.html
 - 标题：可选设置 `GOTIFY_TITLE` 自定义消息标题
 - 示例：`https://gotify.example.com` + `your_app_token`
 - 官网：https://gotify.net/
+
+> 如果没有找到合适的通知服务，可以通过 Apprise 配置需要的通知服务，如 **Email** 通知设置格式 `mailto://user:pass@domain.com`。更新请参考 [Apprise文档](https://github.com/caronc/apprise)。
 
 ### 定时任务配置（scheduled模式）
 | 配置项 | 环境变量 | 默认值 | 说明 |

--- a/README.md
+++ b/README.md
@@ -332,7 +332,9 @@ open config-generator.html
 - 示例：`https://gotify.example.com` + `your_app_token`
 - 官网：https://gotify.net/
 
-> 如果没有找到合适的通知服务，可以通过 Apprise 配置需要的通知服务，如 **Email** 通知设置格式 `mailto://user:pass@domain.com`。更新请参考 [Apprise文档](https://github.com/caronc/apprise)。
+#### 自定义通知服务
+
+如果没有找到合适的通知服务，可以通过 Apprise 配置需要的通知服务，如 **Email** 通知设置格式 `mailto://user:pass@domain.com`。配置请参考 [Apprise文档](https://github.com/caronc/apprise)。
 
 ### 定时任务配置（scheduled模式）
 | 配置项 | 环境变量 | 默认值 | 说明 |

--- a/weread-bot.py
+++ b/weread-bot.py
@@ -4,7 +4,7 @@
 
 项目信息:
     名称: WeRead Bot
-    版本: 0.2.9
+    版本: 0.2.10
     作者: funnyzak
     仓库: https://github.com/funnyzak/weread-bot
     许可: MIT License
@@ -61,7 +61,7 @@ import schedule
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-VERSION = "0.2.9"
+VERSION = "0.2.10"
 REPO = "https://github.com/funnyzak/weread-bot"
 
 

--- a/weread-bot.py
+++ b/weread-bot.py
@@ -4,7 +4,7 @@
 
 项目信息:
     名称: WeRead Bot
-    版本: 0.2.10
+    版本: 0.2.9
     作者: funnyzak
     仓库: https://github.com/funnyzak/weread-bot
     许可: MIT License
@@ -61,7 +61,7 @@ import schedule
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-VERSION = "0.2.10"
+VERSION = "0.2.9"
 REPO = "https://github.com/funnyzak/weread-bot"
 
 


### PR DESCRIPTION
Adjust the default reading duration in the auto-reading workflow to 1-2 minutes and add a pull request trigger. Update the README to clarify Apprise server configuration and notification service options.