### PR TITLE
Add user-level cookie refresh QL configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ python weread-bot.py --dry-run --config config.yaml
 
 # 查看最近一次真实执行结果
 python weread-bot.py --show-last-run --config config.yaml
+
+# 查看所有可用命令
+python weread-bot.py --help
 ```
 
 说明：
@@ -144,6 +147,7 @@ python weread-bot.py --show-last-run --config config.yaml
 - 真实执行结束后，如 `history.enabled=true`，程序会把最近执行摘要写入默认文件 `logs/run-history.json`。
 - 历史记录只保存时间、状态、用户数、阅读统计和失败分类等摘要，不会保存 Cookie、请求头或原始 CURL。
 - 如果 `curl_config.users[].reading_overrides` 中存在不支持的键，程序会直接提示对应配置路径。
+- 如果 `curl_config.users[].cookie_refresh_ql` 不是布尔值，程序会直接提示对应配置路径。
 
 ### 方式六：Docker 方式运行
 
@@ -206,6 +210,7 @@ open config-generator.html
 | 多用户模式 | `curl_config.users` | 配置多个用户的CURL文件和个性化参数 |
 | 用户名称 | `curl_config.users[].name` | 用户标识名称 |
 | CURL文件 | `curl_config.users[].file_path` | 用户专属的CURL文件路径 |
+| Cookie刷新QL覆盖 | `curl_config.users[].cookie_refresh_ql` | 用户级 Cookie 刷新 `ql` 开关，未设置时沿用全局值 |
 | 个性化配置 | `curl_config.users[].reading_overrides` | 用户特定的阅读参数覆盖 |
 
 `curl_config.users[].reading_overrides` 当前支持的键：
@@ -217,6 +222,12 @@ open config-generator.html
 - `fallback_to_config`
 
 如果填写了其他键，`--validate-config` 和 `--dry-run` 会直接报出具体配置路径。
+
+`curl_config.users[].cookie_refresh_ql` 仅支持布尔值：
+
+- `true`: 当前用户刷新 Cookie 时使用 `"ql": true`
+- `false`: 当前用户刷新 Cookie 时使用 `"ql": false`
+- 不填写: 沿用全局 `hack.cookie_refresh_ql`
 
 
 ### 应用配置
@@ -267,9 +278,11 @@ Hack配置用于解决特殊兼容性问题，包含以下选项：
 | Cookie刷新QL属性 | `HACK_COOKIE_REFRESH_QL` | `false` | Cookie刷新时ql属性值设置 |
 
 **详细说明：**
-- `cookie_refresh_ql`: 控制Cookie刷新请求中的`ql`参数值
+- `cookie_refresh_ql`: 控制Cookie刷新请求中的`ql`参数值，作为全局默认值
   - `false` (默认): 使用`"ql": false`
   - `true`: 使用`"ql": true`
+- 多用户模式下，可通过 `curl_config.users[].cookie_refresh_ql` 为单个用户覆盖该值
+- 环境变量 `HACK_COOKIE_REFRESH_QL` 只能设置全局默认值，不能为不同用户分别设置
 - 根据不同用户的环境，可能需要设置为True或False来确保cookie刷新正常工作
 - 如果遇到cookie刷新失败的问题，可以尝试切换此配置的值
 
@@ -277,7 +290,13 @@ Hack配置用于解决特殊兼容性问题，包含以下选项：
 ```yaml
 # config.yaml 示例
 hack:
-  cookie_refresh_ql: false  # 或 true，根据您的环境测试确定
+  cookie_refresh_ql: false  # 全局默认值
+
+curl_config:
+  users:
+    - name: "user1"
+      file_path: "user1_curl.txt"
+      cookie_refresh_ql: true  # 仅覆盖该用户
 ```
 
 ### 执行历史配置
@@ -770,6 +789,7 @@ curl_config:
   users:
     - name: "用户1"                    # 用户标识名称
       file_path: "user1_curl.txt"      # 用户专属的CURL文件路径
+      cookie_refresh_ql: true          # 可选：覆盖全局 hack.cookie_refresh_ql
       reading_overrides:               # 用户特定的阅读参数覆盖（可选）
         target_duration: "45-90"       # 阅读时长
         mode: "smart_random"           # 阅读模式
@@ -788,14 +808,14 @@ curl_config:
 **多用户执行特性：**
 
 - **可控并发**：通过 `MAX_CONCURRENT_USERS` 控制同时在线的账号数量，默认1表示顺序执行
-- **独立配置**：每个用户可以有不同的阅读策略和时长
+- **独立配置**：每个用户可以有不同的阅读策略、时长和 Cookie 刷新 `ql` 开关
 - **错误隔离**：单个用户失败不影响其他用户执行
 - **统计汇总**：提供单用户和多用户的详细统计报告，包含成功、失败、跳过和失败分类汇总
 
 **配置覆盖优先级：**
 
-1. **用户特定配置** (`reading_overrides`) - 最高优先级
-2. **全局配置** (`reading`) - 默认配置  
+1. **用户特定配置** (`reading_overrides` / `curl_config.users[].cookie_refresh_ql`) - 最高优先级
+2. **全局配置** (`reading` / `hack.cookie_refresh_ql`) - 默认配置
 3. **程序默认值** - 最低优先级
 
 ### 2. 智能书籍管理
@@ -1051,10 +1071,12 @@ curl_config:
   users:
     - name: "账号1"
       file_path: "account1_curl.txt"
+      cookie_refresh_ql: true
       reading_overrides:
         target_duration: "45-90"
     - name: "账号2"  
       file_path: "account2_curl.txt"
+      cookie_refresh_ql: false
       reading_overrides:
         target_duration: "30-60"
 ```
@@ -1062,6 +1084,7 @@ curl_config:
 **执行特点：**
 - 通过 `MAX_CONCURRENT_USERS` 控制是否并发执行（默认1则顺序执行）
 - 单个账号失败不影响其他账号
+- 每个账号可独立设置 `cookie_refresh_ql`
 - 提供详细的多用户统计报告
 
 **传统方式（并行运行）：**

--- a/config-generator.html
+++ b/config-generator.html
@@ -1436,6 +1436,17 @@ history:
                                class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
                                data-user-input="${userCount}-target_duration" onchange="updateConfigPreview()">
                     </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Cookie刷新QL（可选）</label>
+                        <select
+                            class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                            data-user-input="${userCount}-cookie_refresh_ql" onchange="updateConfigPreview()">
+                            <option value="">沿用全局默认值</option>
+                            <option value="false">false</option>
+                            <option value="true">true</option>
+                        </select>
+                        <p class="mt-1 text-xs text-gray-500">仅当该用户需要与全局 hack.cookie_refresh_ql 不同时设置。</p>
+                    </div>
                 </div>
             `;
 
@@ -1680,11 +1691,15 @@ history:
                     const name = userElement.querySelector(`[data-user-input="${userId}-name"]`)?.value;
                     const file_path = userElement.querySelector(`[data-user-input="${userId}-file_path"]`)?.value;
                     const target_duration = userElement.querySelector(`[data-user-input="${userId}-target_duration"]`)?.value;
+                    const cookie_refresh_ql = userElement.querySelector(`[data-user-input="${userId}-cookie_refresh_ql"]`)?.value;
 
                     if (name && file_path) {
                         const user = { name, file_path };
                         if (target_duration) {
                             user.reading_overrides = { target_duration };
+                        }
+                        if (cookie_refresh_ql !== "") {
+                            user.cookie_refresh_ql = cookie_refresh_ql === 'true';
                         }
                         config.curl_config.users.push(user);
                     }

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -20,6 +20,7 @@ curl_config:
   users:
     - name: "user1"
       file_path: "user1_curl.txt"
+      cookie_refresh_ql: true
       # 可选：用户特定的阅读参数覆盖
       reading_overrides:
         target_duration: "45-90"
@@ -35,7 +36,7 @@ curl_config:
     
     - name: "user3"
       file_path: "user3_curl.txt"
-      # 不设置overrides则使用全局配置
+      # 不设置 overrides 或 cookie_refresh_ql 时则使用全局配置
 
 # 阅读配置（全局默认配置，可被用户特定配置覆盖）
 reading:
@@ -228,8 +229,8 @@ notification:
 
 # Hack配置（用于解决特殊兼容性问题）
 hack:
-  # Cookie刷新时ql属性设置
-  # 根据不同用户的环境，可能需要设置为True或False来确保cookie刷新正常工作
+  # Cookie刷新时ql属性全局默认值
+  # 多用户模式下可通过 curl_config.users[].cookie_refresh_ql 为单个用户覆盖
   # 默认值：false，如果遇到cookie刷新失败的问题，可以尝试设置为true
   cookie_refresh_ql: false
 

--- a/docs/github-action-autoread-guide.md
+++ b/docs/github-action-autoread-guide.md
@@ -47,7 +47,7 @@ curl 'https://weread.qq.com/web/book/read' -H 'cookie: wr_skey=user2; ...' --dat
 | Secret 名称 | 说明 | 默认值 |
 |------------|------|------|
 | `MAX_CONCURRENT_USERS` | 多用户并发数量（>=1） | 1 |
-| `HACK_COOKIE_REFRESH_QL` | Cookie 刷新兼容开关，遇到刷新失败可切换 true/false | false |
+| `HACK_COOKIE_REFRESH_QL` | Cookie 刷新兼容开关全局默认值，遇到刷新失败可切换 true/false | false |
 | `NOTIFICATION_ONLY_ON_FAILURE` | 仅失败通知开关（true/false），覆盖 workflow 运行参数 | false |
 | `HISTORY_ENABLED` | 是否启用执行历史持久化 | true |
 | `HISTORY_FILE` | 执行历史输出路径 | logs/run-history.json |
@@ -157,12 +157,13 @@ curl 'https://weread.qq.com/web/book/read' -H 'cookie: wr_skey=user2; ...' --dat
 | `HACK_COOKIE_REFRESH_QL` | Cookie刷新时ql属性值设置 | `false` |
 
 > **Hack 配置说明：**
-> - `HACK_COOKIE_REFRESH_QL`: 控制Cookie刷新请求中的`ql`参数值
+> - `HACK_COOKIE_REFRESH_QL`: 控制Cookie刷新请求中的`ql`参数值，作为全局默认值
 >   - `false` (默认): 使用`"ql": false`
 >   - `true`: 使用`"ql": true`
 > - 根据不同用户的环境，可能需要设置为True或False来确保cookie刷新正常工作
 > - 如果遇到cookie刷新失败的问题，可以尝试切换此配置的值
 > - 建议先使用默认值，如果出现cookie相关错误再尝试修改
+> - GitHub Actions Secrets 只能设置全局默认值；如果多用户需要不同取值，请改用配置文件中的 `curl_config.users[].cookie_refresh_ql`
 
 ### 步骤 3: 启用 GitHub Actions
 
@@ -302,12 +303,14 @@ A: 这可能是 `cookie_refresh_ql` 配置问题：
 2. 如果当前设置为 `false`，尝试设置为 `true`
 3. 如果当前设置为 `true`，尝试设置为 `false`
 4. 重新运行 Action 测试
+5. 如果是多用户且仅部分账号失败，请改用配置文件，为对应账号单独设置 `curl_config.users[].cookie_refresh_ql`
 
 ### Q: 如何判断是否需要调整 Hack 配置？
 
 A: 查看运行日志中的错误信息：
 - 搜索关键词：`cookie`、`refresh`、`ql`、`认证`
 - 如果看到 Cookie 相关错误，尝试调整 `HACK_COOKIE_REFRESH_QL` 配置
+- 如果只有某个账号失败，优先检查该账号是否需要单独设置 `curl_config.users[].cookie_refresh_ql`
 - 如果看到 401/403 认证错误，也可能是此配置问题
 
 ## 🔒 安全提示

--- a/weread-bot.py
+++ b/weread-bot.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 项目信息:
     名称: WeRead Bot
-    版本: 0.3.6
+    版本: 0.3.7
     作者: funnyzak
     仓库: https://github.com/funnyzak/weread-bot
     许可: MIT License
@@ -78,7 +78,7 @@ except ImportError:
     croniter = None
 from zoneinfo import ZoneInfo
 
-VERSION = "0.3.6"
+VERSION = "0.3.7"
 REPO = "https://github.com/funnyzak/weread-bot"
 
 
@@ -276,6 +276,7 @@ class UserConfig:
     name: str
     file_path: str = ""
     content: str = ""
+    cookie_refresh_ql: Optional[bool] = None
     reading_overrides: Dict[str, Any] = field(default_factory=dict)
 
 
@@ -1187,6 +1188,9 @@ class ConfigManager:
                         name=user_data.get("name"),
                         file_path=user_data.get("file_path", ""),
                         content=user_data.get("content", ""),
+                        cookie_refresh_ql=user_data.get(
+                            "cookie_refresh_ql"
+                        ),
                         reading_overrides=user_data.get(
                             "reading_overrides", {}
                         )
@@ -3054,8 +3058,11 @@ class WeReadSessionManager:
         )
         self.session_stats = ReadingSession(user_name=self.user_name)
 
-        # 动态创建cookie数据，使用配置中的ql值
-        self.cookie_data = {"rq": "%2Fweb%2Fbook%2Fread", "ql": config.hack.cookie_refresh_ql}
+        # 动态创建 cookie 数据，优先使用用户级 ql 配置
+        self.cookie_data = {
+            "rq": "%2Fweb%2Fbook%2Fread",
+            "ql": self._resolve_cookie_refresh_ql(),
+        }
 
         self.headers = {}
         self.cookies = {}
@@ -3064,6 +3071,13 @@ class WeReadSessionManager:
 
         self._load_curl_config()
         self._initialize_session_user_agent()
+
+    def _resolve_cookie_refresh_ql(self) -> bool:
+        """解析当前用户会话的 Cookie 刷新 ql 配置"""
+        if (self.user_config
+                and isinstance(self.user_config.cookie_refresh_ql, bool)):
+            return self.user_config.cookie_refresh_ql
+        return self.config.hack.cookie_refresh_ql
 
     def _apply_reading_overrides(
         self, base_config: ReadingConfig, user_config: UserConfig
@@ -3994,6 +4008,16 @@ def _build_user_config_summary_lines(config: WeReadConfig) -> List[str]:
             if key in user_config.reading_overrides
             and key in USER_TIME_STRATEGY_FIELDS
         ]
+        if user_config.cookie_refresh_ql is None:
+            cookie_refresh_ql_desc = (
+                "沿用全局 hack.cookie_refresh_ql "
+                f"({_format_config_value(config.hack.cookie_refresh_ql)})"
+            )
+        else:
+            cookie_refresh_ql_desc = (
+                "用户级覆盖 "
+                f"({_format_config_value(user_config.cookie_refresh_ql)})"
+            )
         summary_lines.extend([
             f"  - 用户: {user_config.name}",
             (
@@ -4010,6 +4034,7 @@ def _build_user_config_summary_lines(config: WeReadConfig) -> List[str]:
                 "    独立时间策略: 否（沿用全局 reading.target_duration / "
                 "reading.reading_interval）"
             ),
+            f"    Cookie刷新QL: {cookie_refresh_ql_desc}",
             f"    覆盖差异: {_build_user_override_diff(user_config, config.reading)}",
         ])
 
@@ -4127,6 +4152,12 @@ def _validate_runtime_config(config: WeReadConfig):
                         f"{user_path}.reading_overrides.{invalid_key} 不支持，"
                         f"允许项: {allowed_override_keys}"
                     )
+
+            if (user_config.cookie_refresh_ql is not None
+                    and not isinstance(user_config.cookie_refresh_ql, bool)):
+                validation_errors.append(
+                    f"{user_path}.cookie_refresh_ql 必须是布尔值"
+                )
 
             if not user_config.file_path and not user_config.content:
                 validation_errors.append(


### PR DESCRIPTION
Introduce support for user-specific cookie refresh QL settings, allowing individual users to override the global configuration. Update documentation and examples accordingly.