### PR TITLE
fix: avoid Latin-1 encoding error in Ntfy notifications

### DIFF
--- a/weread-bot.py
+++ b/weread-bot.py
@@ -2303,15 +2303,15 @@ class NotificationService:
             logging.error("❌ Ntfy配置不完整（需要server和topic）")
             return False
 
-        # 构建Ntfy URL
-        ntfy_url = (f"{config['server'].rstrip('/')}/"
-                    f"{config['topic']}")
+        # 使用 JSON 发布，避免中文标题放入 HTTP 头时触发 Latin-1 编码错误
+        ntfy_url = config["server"].rstrip("/")
 
         try:
-            # 准备请求头
-            headers = {
-                "Content-Type": "text/plain; charset=utf-8",
-                "Title": "微信读书自动阅读报告"
+            headers = {}
+            payload = {
+                "topic": config["topic"],
+                "message": message,
+                "title": "微信读书自动阅读报告",
             }
 
             # 添加认证token（如果配置了）
@@ -2321,7 +2321,7 @@ class NotificationService:
             # 发送POST请求
             response = requests.post(
                 ntfy_url,
-                data=message.encode('utf-8'),
+                json=payload,
                 headers=headers,
                 timeout=10
             )


### PR DESCRIPTION
## 变更

- 将 Ntfy 通知从“UTF-8 正文 + 中文 `Title` 请求头”改为官方支持的 JSON 发布格式。
- 在 JSON 请求体中发送 `topic`、`message` 和 `title`，认证令牌仍通过 `Authorization` 请求头发送。

## 原因

Python `requests`/`urllib3` 会按 Latin-1 序列化 HTTP 请求头。原实现把 `微信读书自动阅读报告` 直接写入 `Title` 请求头，因此发送前就会抛出：

```text
'latin-1' codec can't encode characters in position 0-9
```

JSON 请求体由 `requests` 正确编码，避免非 ASCII HTTP 请求头，同时保留中文标题和正文。

## 验证

- `python3 -m py_compile weread-bot.py`
- 使用伪造的 `requests.post` 验证 URL、JSON 请求体和 Bearer Token 请求头。
- 在 Docker 运行环境中向 `ntfy.sh` 发送真实中文通知，客户端已成功收到正确标题和正文。
